### PR TITLE
Add Dockerfile

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,7 @@
+.git
+.gitignore
+LICENSE
+*.md
+*.dist
+node_modules
+npm-debug.log

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,8 @@
+FROM node:11
+
+WORKDIR /usr/src/app
+COPY package*.json ./
+RUN npm install
+COPY . .
+
+CMD ["node", "main.js"]


### PR DESCRIPTION
One of the dependencies ([hashtable](https://www.npmjs.com/package/hashtable)) compiles native code, and errors because of API differences on all versions but Node v11.x.

I added a Dockerfile so I can run it locally for development. It would probably make CI easier as well if it was uploaded to [dockerhub](https://hub.docker.com/)